### PR TITLE
Options for using the cache and specifying rules

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,22 @@
+// A launch configuration that launches the extension inside a new window
+{
+    "version": "0.1.0",
+    "configurations": [
+        {
+            "name": "Extension",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
+            "stopOnEntry": false
+        },
+        {
+            "name": "Extension Tests",
+            "type": "extensionHost",
+            "request": "launch",
+            "runtimeExecutable": "${execPath}",
+            "args": ["--extensionDevelopmentPath=${workspaceRoot}", "--extensionTestsPath=${workspaceRoot}/test" ],
+            "stopOnEntry": false
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Run the fixer on save?
 
 `"simple-php-cs-fixer.save": false`
 
+Whether php-cs-fixer should be using a cache
+
+`"simple-php-cs-fixer.usingCache": false`
+
+A comma separated list of rules to be used by php-cs-fixer
+
+`"simple-php-cs-fixer.rules": "@PSR1,@PSR2,trailing_comma_in_multiline_array"`
+
 ---
 
 \- Enjoy!

--- a/extension.js
+++ b/extension.js
@@ -32,6 +32,14 @@ PhpCsFixer.prototype.getArgs = function (document) {
         }
     }
 
+    if (!this.usingCache) {
+        args.push('--using-cache=no');
+    }
+
+    if (this.rules) {
+        args.push('--rules=' + this.rules)
+    }
+
     return args;
 }
 
@@ -66,6 +74,8 @@ PhpCsFixer.prototype.loadConfig = function () {
     this.useConfigFile = config.get('useConfig');
     this.configFile = config.get('config');
     this.runOnSave = config.get('save');
+    this.usingCache = config.get('usingCache');
+    this.rules = config.get('rules');
 
     if (this.runOnSave && ! willFixOnSave) {
         willFixOnSave = vscode.workspace.onDidSaveTextDocument(document => {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
                 "simple-php-cs-fixer.useConfig": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Weather or not to use a custom config file"
+                    "description": "Whether to use a custom config file"
                 },
                 "simple-php-cs-fixer.config": {
                     "type": "string",
@@ -49,6 +49,16 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Run PHP CS Fixer on save"
+                },
+                "simple-php-cs-fixer.usingCache": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to use the php-cs-fixer cache"
+                },
+                "simple-php-cs-fixer.rules": {
+                    "type": "string",
+                    "default": "",
+                    "description": "A comma separated list of rules php-cs-fixer will apply using the --rules option"
                 }
             }
         }


### PR DESCRIPTION
Hi @calebporzio,

This is a quick PR that adds options for using the cache and specifying rules:

Setting usingCache to false will stop the creation of a .php_cs.cache file every time php-cs-fixer runs.

Specifying rules allows you to use rules included with php-cs-fixer. Read about them at https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/2.8/README.rst.

PS - I also fixed a spelling error.