### PR TITLE
Adds "auto" mode for "runOnSave" configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ The path to that config file. (relative to the project root)
 
 Run the fixer on save?
 
-`"simple-php-cs-fixer.save": false`
+`"simple-php-cs-fixer.save": true`
+
+Run the fixer on save, only for projects which have your configuration file present on the project root?
+
+`"simple-php-cs-fixer.save": "auto"` (This requires a value to be present for the `"simple-php-cs-fixer.config"` option)
 
 Whether php-cs-fixer should be using a cache
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "color": "#f0f1f6",
         "theme": "light"
     },
-    "version": "0.1.5",
+    "version": "0.1.6",
     "publisher": "calebporzio",
     "engines": {
         "vscode": "^1.17.0"
@@ -46,7 +46,12 @@
                     "description": "PHP CS Fixer custom config file name"
                 },
                 "simple-php-cs-fixer.save": {
-                    "type": "boolean",
+                    "type": ["boolean", "string"],
+                    "enum": [
+                        true,
+                        false,
+                        "auto"
+                    ],
                     "default": false,
                     "description": "Run PHP CS Fixer on save"
                 },


### PR DESCRIPTION
I've been using this extension since I heard you mention it on your 20% time podcast (new episodes, ps?).

One issue I've had is that I have a lot of old projects that don't exactly follow PSR2, or...anything close, coding standards.

That's a problem because it basically makes it impossible to make simple fixes on a code base without also fixing the inconsistent coding standard. This turns what would normally be a 2-10 line change in a file to be a 80% rewrite..which makes historical blame parsing, and conflict merging, impossible.

To solve this issue, I added an "auto" option to the `runOnSave` configuration option. If you specify `"auto"`, and have a `simple-php-cs-fixer` configured to use a config file, the extension will check the presence of the config file on the workspace.  If it is there, it will run the fixer, if it isn't, it won't.

This seemed like a pretty simple addition that other people might benefit from. 

I'd appreciate your feedback, let me know if there's anything I need to change or overlooked!