### PR TITLE
Add support for a custom executable php-cs-fixer & docker paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A simple extension for using php-cs-fixer in VS Code.
 
 If no .php_cs.dist file (or other configuration) is found, it will use the default configuration for the Laravel project: https://gist.github.com/laravel-shift/cab527923ed2a109dda047b97d53c200
 
+Now includes support for docker container-based php-cs-fixer!
+
 ![Demo Gif](demo.gif)
 
 ---
@@ -15,26 +17,59 @@ If no .php_cs.dist file (or other configuration) is found, it will use the defau
 
 ## Config:
 
-Look for a custom project specific config file?
+- **executablePath** - The path to your php-cs-fixer (make sure you've installed with composer)
 
-`"simple-php-cs-fixer.useConfig": true`
+  `"simple-php-cs-fixer.executablePath": "php-cs-fixer"`
 
-The path to that config file. (relative to the project root)
+- **useConfig** - Look for a custom project specific config file?
 
-`"simple-php-cs-fixer.config": ".php_cs.dist"`
+  `"simple-php-cs-fixer.useConfig": true`
 
-Run the fixer on save?
+- **config** - The path to that config file. (relative to the project root)
 
-`"simple-php-cs-fixer.save": false`
+  `"simple-php-cs-fixer.config": ".php_cs.dist"`
 
-Whether php-cs-fixer should be using a cache
+- **save** - Run the fixer on save?
 
-`"simple-php-cs-fixer.usingCache": false`
+  `"simple-php-cs-fixer.save": false`
 
-A comma separated list of rules to be used by php-cs-fixer
+- **usingCache** - Whether php-cs-fixer should be using a cache
 
-`"simple-php-cs-fixer.rules": "@PSR1,@PSR2,trailing_comma_in_multiline_array"`
+  `"simple-php-cs-fixer.usingCache": false`
 
+- **rules** - A comma separated list of rules to be used by php-cs-fixer
+
+  `"simple-php-cs-fixer.rules": "@PSR1,@PSR2,trailing_comma_in_multiline_array"`
+
+---
+
+## Config for Docker
+
+If running PHP/php-cs-fixer in a docker container, you can use these configuration options.
+
+
+- **hostPath** - The absolute path to your project on your host machine. Eg. "/Users/you/code/project". Filling this out will help replace it with your dockerPath.
+
+  `"simple-php-cs-fixer.hostPath": "/path-to-your-project-in-host-machine"`
+
+- **dockerPath** - The absolute path to your project on your docker container. Eg. "/var/www/project". This will help with replacing your hostPath with this dockerPath so that your paths are relative to your docker's php-cs-fixer.
+
+  `"simple-php-cs-fixer.dockerPath": "/path-to-your-project-in-docker-container"`
+
+- **executablePath** - Use the executablePath to point to docker exec wrapped in script. Eg. "/Users/you/code/project/docker-php-cs-fixer"
+
+  `"simple-php-cs-fixer.executablePath": "/path-to-script-on-host-machine"`
+
+  For example, you could create a script in your project called `docker-php-cs-fixer` with following contents:
+
+  ```
+  #!/bin/bash
+
+  docker exec -t "yourcontainer" /var/www/your-project/vendor/bin/php-cs-fixer $@
+  ```
+
+  Note: `chmod +x yourscript` to make executable.
+  
 ---
 
 \- Enjoy!

--- a/package.json
+++ b/package.json
@@ -1,78 +1,98 @@
 {
-    "name": "simple-php-cs-fixer",
-    "displayName": "Simple PHP CS Fixer",
-    "description": "A simple way to fire php-cs-fixer with custom config and optionally on save.",
-    "icon": "icon.png",
-    "galleryBanner": {
-        "color": "#f0f1f6",
-        "theme": "light"
-    },
-    "version": "1.0.3",
-    "publisher": "calebporzio",
-    "engines": {
-        "vscode": "^1.17.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/calebporzio/simple-php-cs-fixer.git"
-    },
-    "categories": [
-        "Linters",
-        "Other"
-    ],
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "simple-php-cs-fixer.fix",
-                "title": "Simple PHP CS Fixer: fix"
-            }
-        ],
-        "configuration": {
-            "title": "Simple PHP CS Fixer Config",
-            "type": "object",
-            "properties": {
-                "simple-php-cs-fixer.useConfig": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Whether to use a custom config file"
-                },
-                "simple-php-cs-fixer.config": {
-                    "type": "string",
-                    "default": ".php_cs.dist",
-                    "description": "PHP CS Fixer custom config file name"
-                },
-                "simple-php-cs-fixer.save": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Run PHP CS Fixer on save"
-                },
-                "simple-php-cs-fixer.usingCache": {
-                    "type": "boolean",
-                    "default": false,
-                    "description": "Whether to use the php-cs-fixer cache"
-                },
-                "simple-php-cs-fixer.rules": {
-                    "type": "string",
-                    "default": "",
-                    "description": "A comma separated list of rules php-cs-fixer will apply using the --rules option"
-                }
-            }
-        }
-    },
-    "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
-    },
-    "devDependencies": {
-        "@types/mocha": "^2.2.48",
-        "@types/node": "^7.10.9",
-        "eslint": "^4.19.1",
-        "mocha": "^6.2.2",
-        "typescript": "^2.9.2",
-        "vscode": "^1.1.36"
-    }
+	"name": "simple-php-cs-fixer",
+	"displayName": "Simple PHP CS Fixer",
+	"description": "A simple way to fire php-cs-fixer with custom config and optionally on save.",
+	"icon": "icon.png",
+	"galleryBanner": {
+		"color": "#f0f1f6",
+		"theme": "light"
+	},
+	"version": "1.0.3",
+	"publisher": "calebporzio",
+	"engines": {
+		"vscode": "^1.17.0"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/calebporzio/simple-php-cs-fixer.git"
+	},
+	"categories": [
+		"Linters",
+		"Other"
+	],
+	"activationEvents": [
+		"*"
+	],
+	"main": "./extension",
+	"contributes": {
+		"commands": [
+			{
+				"command": "simple-php-cs-fixer.fix",
+				"title": "Simple PHP CS Fixer: fix"
+			}
+		],
+		"configuration": {
+			"title": "Simple PHP CS Fixer Config",
+			"type": "object",
+			"properties": {
+				"simple-php-cs-fixer.executablePath": {
+					"type": "string",
+					"default": "php-cs-fixer",
+					"description": "The path to your php-cs-fixer, which could be a script that exposes this via docker exec."
+				},
+				"simple-php-cs-fixer.useConfig": {
+					"type": "boolean",
+					"default": true,
+					"description": "Whether to use a custom config file"
+				},
+				"simple-php-cs-fixer.config": {
+					"type": "string",
+					"default": ".php_cs.dist",
+					"description": "PHP CS Fixer custom config file name"
+				},
+				"simple-php-cs-fixer.hostPath": {
+					"type": "string",
+					"default": "",
+					"description": "This is your project path from your host machine - use in combination with dockerPath to 'replace' filename path."
+				},
+				"simple-php-cs-fixer.dockerPath": {
+					"type": "string",
+					"default": "",
+					"description": "This is your project path from within your container"
+				},
+				"simple-php-cs-fixer.save": {
+					"type": "boolean",
+					"default": false,
+					"description": "Run PHP CS Fixer on save"
+				},
+				"simple-php-cs-fixer.usingCache": {
+					"type": "boolean",
+					"default": false,
+					"description": "Whether to use the php-cs-fixer cache"
+				},
+				"simple-php-cs-fixer.rules": {
+					"type": "string",
+					"default": "",
+					"description": "A comma separated list of rules php-cs-fixer will apply using the --rules option"
+				}
+			}
+		}
+	},
+	"scripts": {
+		"postinstall": "node ./node_modules/vscode/bin/install",
+		"test": "node ./node_modules/vscode/bin/test"
+	},
+	"devDependencies": {
+		"@types/mocha": "^2.2.48",
+		"@types/node": "^7.10.9",
+		"eslint": "^4.19.1",
+		"mocha": "^6.2.2",
+		"typescript": "^2.9.2",
+		"vscode": "^1.1.36"
+	},
+	"__metadata": {
+		"id": "7b273093-b24a-4814-b10d-1d272e2b37ba",
+		"publisherId": "a2487481-f6cb-4f67-9340-4db67a69d30d",
+		"publisherDisplayName": "calebporzio"
+	}
 }


### PR DESCRIPTION
I'm posing this PR more as a suggestion or offer - not as final code, necessarily.

I was running into an issue of not wanting to install php locally in order to support php-cs-fixer - but instead run it through my project's corresponding docker container.

With a few more configuration settings, you can offer the option to swap out the php-cs-fixer to another executable (in my case, docker exec... ) and you can ask users for paths to swap out so they can be relative to the container instead of the host machine.

Explained by issue here:

https://stackoverflow.com/questions/67067987/how-to-use-php-cs-fixer-in-vscode-with-docker-container-for-php-and-composer/67067988#67067988