### PR TITLE
Added Executable Path configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ If no .php_cs.dist file (or other configuration) is found, it will use the defau
 
 ## Config:
 
+Override the path to the `php-cs-fixer` executable file. This path can be 
+absolue or relative to the current projects root directory.
+
+`"simple-php-cs-fixer.executablePath": "php-cs-fixer"`
+
 Look for a custom project specific config file?
 
 `"simple-php-cs-fixer.useConfig": true`

--- a/extension.js
+++ b/extension.js
@@ -14,7 +14,9 @@ PhpCsFixer.prototype.fix = function (document) {
         return;
     }
 
-    const process = cp.spawn('php-cs-fixer', this.getArgs(document));
+    const process = cp.spawn(this.executablePath, this.getArgs(document), {
+        cwd: vscode.workspace.workspaceFolders[0].uri.path
+    });
 
     this.handleProcessOutput(process);
 }
@@ -74,6 +76,7 @@ PhpCsFixer.prototype.handleProcessOutput = function (process) {
 PhpCsFixer.prototype.loadConfig = function () {
     const config = vscode.workspace.getConfiguration('simple-php-cs-fixer');
 
+    this.executablePath = config.get('executablePath');
     this.useConfigFile = config.get('useConfig');
     this.configFile = config.get('config');
     this.runOnSave = config.get('save');

--- a/package.json
+++ b/package.json
@@ -35,6 +35,11 @@
             "title": "Simple PHP CS Fixer Config",
             "type": "object",
             "properties": {
+                "simple-php-cs-fixer.executablePath": {
+                    "type": "string",
+                    "default": "php-cs-fixer",
+                    "description": "Path to the php-cs-fixer executable file. Can be absolue or relative to the root project directory"
+                },
                 "simple-php-cs-fixer.useConfig": {
                     "type": "boolean",
                     "default": true,


### PR DESCRIPTION
Added the "Executable Path" configuration option. This allows overriding the path to the `php-cs-fixer` executable file path. This file path can be absolute or relative to the root project directory.

This is useful when you have `php-cs-fixer` installed globally _and_ locally (in the project) and want to override the default executable resolution (usually the globally installed executable) with the other (usually the project-installed executable).

To accomplish this change it was also necessary to set the working directory of the spawned child process.

Supersedes #15